### PR TITLE
validate_release: do not expect useless symbols/ folder in symbols_0.zip

### DIFF
--- a/validate_release.py
+++ b/validate_release.py
@@ -220,7 +220,7 @@ def Symbols(z, symids):
     for filename in z.namelist():
         if not filename.endswith('.sym'):
             continue
-        m = re.fullmatch(r'symbols/([^/]+)/([0-9A-F]+)/([^/]+)\.sym', filename)
+        m = re.fullmatch(r'([^/]+)/([0-9A-F]+)/([^/]+)\.sym', filename)
         if not m:
             yield 'Symbol filename %r does not match expected pattern' % filename
             continue


### PR DESCRIPTION
Do not expect useless `symbols/` folder in `symbols_0.zip`.

It would be needed once this is merged:

- https://github.com/Unvanquished/release-scripts/pull/19

That other PR removes that folder when producing release zip archives.