### PR TITLE
0.54 updates

### DIFF
--- a/validate_release.py
+++ b/validate_release.py
@@ -386,7 +386,7 @@ def CheckDependencyGraph(depmap):
             yield from VisitPak(dep)
         stack.pop()
 
-    for root in {name for name, _ in depmap if name == 'unvanquished' or name.startswith('map-')}:
+    for root in {name for name, _ in depmap if name in ['unvanquished', 'res-leveleditor'] or name.startswith('map-')}:
         yield from VisitPak((root, None))
     for leftover in set(depmap) - visited:
         yield 'No pak depends on ' + PakFilename(leftover)

--- a/validate_release.py
+++ b/validate_release.py
@@ -39,9 +39,10 @@ def TempUnzip(z, filename):
 # https://unix.stackexchange.com/a/14727
 def CheckUnixPermissions(z):
     normal = 0o644, 0o755
+    symlink = 0o120777 # Alternative permissions for symlink
     for info in z.infolist():
-        permissions = (info.external_attr >> 16) & 0o7777
-        if permissions not in normal:
+        permissions = info.external_attr >> 16
+        if permissions & 0o7777 not in normal and permissions != symlink:
             yield f"File '{info.filename}' in {z.filename} has odd permissions {oct(permissions)}"
 
 def LinuxCheckSymbolVersions(elf, binary):

--- a/validate_release.py
+++ b/validate_release.py
@@ -424,6 +424,8 @@ def CheckPkg(z, base, number, symids):
         name = fullname[len(base):]
         m = re.fullmatch(r'([^_/]+)_([^_/]+)\.dpk', name)
         if m:
+            if '-dirty' in m.group(2):
+                yield 'Dirty version string detected: ' + name
             deps = []
             if m.group(1) != 'unvanquished':
                 unv = 0


### PR DESCRIPTION
The output now looks like this:
```
Checking the universal zip (version = '0.54.0')
Dirty version string detected: unvanquished_0.54.0/pkg/res-weapons_0.54-dirty.dpk
Pak dependency cycle: res-weapons_0.54-dirty.dpk -> res-buildables_0.54.dpk -> res-weapons_0.54-dirty.dpk
Linux binary daemon (i686) depends on a too-new symbol version GLIBC_2.28
Linux binary daemonded (i686) depends on a too-new symbol version GLIBC_2.28
Linux binary daemon-tty (i686) depends on a too-new symbol version GLIBC_2.28
File 'Unvanquished.app/Contents/MacOS/SDL2.framework/SDL2' in unvanquished_0.54.0/macos-amd64.zip has odd permissions0o777
File 'Unvanquished.app/Contents/MacOS/SDL2.framework/Versions/A/Frameworks/hidapi.framework/hidapi' in unvanquished_0.54.0/macos-amd64.zip has odd permissions 0o777
File 'Unvanquished.app/Contents/MacOS/SDL2.framework/Versions/Current/Frameworks/hidapi.framework/hidapi' in unvanquished_0.54.0/macos-amd64.zip has odd permissions 0o777
```