### PR TITLE
add libgomp as Linux dependency

### DIFF
--- a/validate_release.py
+++ b/validate_release.py
@@ -112,6 +112,7 @@ def LinuxCheckBinary(z, arch, binary, symids):
         'libc.so.6',
         'libdl.so.2',
         'libgcc_s.so.1',
+        'libgomp.so.1',
         'libm.so.6',
         'libpthread.so.0',
         'librt.so.1',


### PR DESCRIPTION
Add libgomp as Linux dependency.

Required after:

- https://github.com/Unvanquished/release-scripts/pull/43